### PR TITLE
Check if kibana index exists correctly

### DIFF
--- a/lib/appmetrics-elk.js
+++ b/lib/appmetrics-elk.js
@@ -73,7 +73,7 @@ var monitor = function (opts) {
 	});
     
     /*
-     * Check to see if there are any Kibana index format mappings for appmetrics, if not:
+     * Check to see if there are any Kibana index format mappings for the index, if not:
      * 1) Set the index format mappings
      * 2) Upload default charts
      * 3) Upload default dashboards
@@ -81,7 +81,13 @@ var monitor = function (opts) {
     esearch.searchExists({
 		index: '.kibana',
 		type : 'index-pattern',
-		id: INDEX
+		body: {
+			query: {
+				match: {
+					_id: INDEX
+				}
+			}
+		}
 	}, function (err, res) {
 		if (!res.exists === true) {
     		putIndexes(esearch);


### PR DESCRIPTION
Changes the searchExists call to query the Kibana index-pattern for the index we're configured to send data to, rather than just any Kibana index-pattern entry.
