### PR TITLE
Add error checking for failed ES connections

### DIFF
--- a/lib/appmetrics-elk.js
+++ b/lib/appmetrics-elk.js
@@ -46,11 +46,15 @@ var monitor = function (opts) {
     esearch.indices.exists({
     	'index':	INDEX
     }, function (err, res){
-    	if (res === false) {
+    	if (!err && res === false) {
     	    esearch.indices.create({
     	    	'index':	INDEX
     	    }, function (err, res) { 
-    	    	putMappings(esearch, INDEX);
+    	    	if (err) {
+    	    		console.log('Failed to create index ' + INDEX);
+    	    	} else {
+    	    		putMappings(esearch, INDEX);
+    	    	}
     	    });
     	}
     	startMonitoring();
@@ -67,7 +71,7 @@ var monitor = function (opts) {
 		index: '.kibana',
 		type : 'config'
 	}, function (err, res) {
-		if (!res.exists === true) {
+		if (!err && !res.exists === true) {
 			putConfigs(esearch);
 		}
 	});
@@ -89,7 +93,7 @@ var monitor = function (opts) {
 			}
 		}
 	}, function (err, res) {
-		if (!res.exists === true) {
+		if (!err && !res.exists === true) {
     		putIndexes(esearch);
     		putCharts(esearch);
     		putDashboards(esearch);


### PR DESCRIPTION
This PR covers issue #5 

There appears to be no easy way of determining that the connection has failed due to an invalid URL (vs. a temporary failure), so the best that can be done is to do better error handling on the client calls - which we should have been doing anyway.
