### PR TITLE
Switch to handling underfined results

### DIFF
--- a/lib/appmetrics-elk.js
+++ b/lib/appmetrics-elk.js
@@ -71,8 +71,10 @@ var monitor = function (opts) {
 		index: '.kibana',
 		type : 'config'
 	}, function (err, res) {
-		if (!err && !res.exists === true) {
-			putConfigs(esearch);
+		if (typeof(res) !== 'undefined') {
+			if (!res.exists === true) {
+				putConfigs(esearch);
+			}
 		}
 	});
     
@@ -93,10 +95,12 @@ var monitor = function (opts) {
 			}
 		}
 	}, function (err, res) {
-		if (!err && !res.exists === true) {
-    		putIndexes(esearch);
-    		putCharts(esearch);
-    		putDashboards(esearch);
+		if (typeof(res) !== 'undefined') {
+			if (!res.exists === true) {
+				putIndexes(esearch);
+				putCharts(esearch);
+				putDashboards(esearch);
+			}
 		}
 	});
     


### PR DESCRIPTION
It turns out we can't just check for errors reported from the client to see if no connection to ES is available - calls to `client.searchExists()` also return an error if the index doesn't exist.

Switching to checking for a valid result handles both scenarios.
