### PR TITLE
Return appmetrics rather than monitor object

### DIFF
--- a/lib/appmetrics-elk.js
+++ b/lib/appmetrics-elk.js
@@ -272,7 +272,7 @@ var monitor = function (opts) {
     	});	
 	};
 	
-	return monitor;
+	return appmetrics;
 };
 
 function Entry(type, time) {


### PR DESCRIPTION
This PR covers issue #15 and simply switches the return object to the correct one.
