### PR TITLE
Update to work with Elasticsearch 2.x

### DIFF
--- a/mappings/cpu.json
+++ b/mappings/cpu.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "cpu",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},

--- a/mappings/eventloop.json
+++ b/mappings/eventloop.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "eventloop",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},
@@ -13,9 +12,15 @@
                 "type": "nested",
                 "include_in_parent": true,
                 "properties": {
-                    "latency.min":	{"type": "long"},
-                    "latency.max":	{"type": "long"},
-                    "latency.avg":	{"type": "long"}
+                	"latency": {
+                        "type": "nested",
+                        "include_in_parent": true,
+                        "properties": {
+                            "min":	{"type": "long"},
+                            "max":	{"type": "long"},
+                            "avg":	{"type": "long"}
+                        }
+                	}
                 }
             }
         }

--- a/mappings/gc.json
+++ b/mappings/gc.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "gc",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},

--- a/mappings/http.json
+++ b/mappings/http.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "http",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},
@@ -13,7 +12,7 @@
                 "type": "nested",
                 "include_in_parent": true,
                 "properties": {
-                    "method":     {"type": "string", "index": "not_analyzed"},            
+                    "method":     {"type": "string", "index": "not_analyzed"},
                     "url":        {"type": "string", "index": "not_analyzed"},
                     "duration":   {"type": "long"}
                 }

--- a/mappings/leveldown.json
+++ b/mappings/leveldown.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "leveldown",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},

--- a/mappings/memcached.json
+++ b/mappings/memcached.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "memcached",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},

--- a/mappings/memory.json
+++ b/mappings/memory.json
@@ -2,29 +2,34 @@
     "index":  "appmetrics",
     "type":   "memory",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},
             "hostName":         {"type": "string", "index": "not_analyzed"},
             "pid":              {"type": "integer"},
             "applicationName":  {"type": "string", "index": "not_analyzed"},
-            "memory.process" : {
+            "memory" : {
                 "type": "nested",
                 "include_in_parent": true,
                 "properties": {
-                    "private":  {"type": "long"},
-                    "physical": {"type": "long"},
-                    "virtual":  {"type": "long"}
+                	"process" : {
+                		"type": "nested",
+                		"include_in_parent": true,
+                		"properties": {
+                			"private":  {"type": "long"},
+                			"physical": {"type": "long"},
+                			"virtual":  {"type": "long"}
+                		}
+                	},
+                	"system" : {
+                		"type": "nested",
+                		"include_in_parent": true,
+                		"properties": {
+                			"physical": {"type": "long"},
+                			"total":    {"type": "long"}
+                		}
+                	}
                 }
-            },
-            "memory.system" : {
-                "type": "nested",
-                "include_in_parent": true,
-                "properties": {
-                    "physical": {"type": "long"},
-                    "total":    {"type": "long"}
-                }                           
             }
         }
     }

--- a/mappings/mongo.json
+++ b/mappings/mongo.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "mongo",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},

--- a/mappings/mqlight.json
+++ b/mappings/mqlight.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "mqlight",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},

--- a/mappings/mqtt.json
+++ b/mappings/mqtt.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "mqtt",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},

--- a/mappings/mysql.json
+++ b/mappings/mysql.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "mysql",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},

--- a/mappings/postgres.json
+++ b/mappings/postgres.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "postgres",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},

--- a/mappings/redis.json
+++ b/mappings/redis.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "redis",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},

--- a/mappings/socketio.json
+++ b/mappings/socketio.json
@@ -2,7 +2,6 @@
     "index":  "appmetrics",
     "type":   "socketio",
     "body": {
-        "_source" : {"compress" : true},
         "_ttl" : {"enabled" : true, "default" : "90d"},
         "properties": {
             "timestamp":        {"type": "date", "format": "dateOptionalTime"},


### PR DESCRIPTION
This PR is for issue #8 in that it provides support for Elasticsearch 2.x which is required in order to run later versions of Kibana.

This required modifications to the mapping files due to the breaking changes in ES 2.x. This required:
- the removal of dot names in properties. This can been done by using sub-objects with nested/include_in_parent, which means there's no backward compatibility issues
- the removal of the compression statement (which is not require)
  Both changes have been tested for backward compatibility

It won't however configure 'appmetrics' (or whichever index was specified in the config) as the default index for Kibana, so the user will need to specify that themselves.
