### PR TITLE
fixed appmetrics dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ELK Connector for Node Application Metrics",
   "main": "index.js",
   "dependencies": {
-    "appmetrics": "^1.0.4",
+    "appmetrics": "^3.0.0",
     "elasticsearch": "*"
   },
   "scripts": {


### PR DESCRIPTION
FIXES this error:
________

> Unsupported version v8.4.0. Exiting.
> npm ERR! code ELIFECYCLE
> npm ERR! errno 1
> npm ERR! appmetrics@1.2.0 install: `node extract_all_binaries.js`
> npm ERR! Exit status 1